### PR TITLE
Add product modifier support

### DIFF
--- a/src/headless/store/services/product-modifiers-service.ts
+++ b/src/headless/store/services/product-modifiers-service.ts
@@ -1,0 +1,153 @@
+import {
+  defineService,
+  implementService,
+  type ServiceFactoryConfig,
+} from "@wix/services-definitions";
+import { SignalsServiceDefinition } from "@wix/services-definitions/core-services/signals";
+import type { Signal, ReadOnlySignal } from "../../Signal";
+import { productsV3 } from "@wix/stores";
+
+export interface ModifierValue {
+  modifierName: string;
+  choiceValue?: string; // For SWATCH_CHOICES and TEXT_CHOICES
+  freeTextValue?: string; // For FREE_TEXT
+}
+
+export interface ProductModifiersServiceAPI {
+  modifiers: ReadOnlySignal<productsV3.ConnectedModifier[]>;
+  selectedModifiers: Signal<Record<string, ModifierValue>>;
+  hasModifiers: ReadOnlySignal<boolean>;
+  isLoading: Signal<boolean>;
+  error: Signal<string | null>;
+
+  setModifierChoice: (modifierName: string, choiceValue: string) => void;
+  setModifierFreeText: (modifierName: string, freeTextValue: string) => void;
+  clearModifier: (modifierName: string) => void;
+  clearAllModifiers: () => void;
+  getModifierValue: (modifierName: string) => ModifierValue | null;
+  isModifierRequired: (modifierName: string) => boolean;
+  hasRequiredModifiers: () => boolean;
+  areAllRequiredModifiersFilled: () => boolean;
+}
+
+export const ProductModifiersServiceDefinition =
+  defineService<ProductModifiersServiceAPI>("productModifiers");
+
+export const ProductModifiersService = implementService.withConfig<{
+  product: productsV3.V3Product;
+}>()(ProductModifiersServiceDefinition, ({ getService, config }) => {
+  const signalsService = getService(SignalsServiceDefinition);
+
+  const configProduct = config.product;
+
+  const selectedModifiers: Signal<Record<string, ModifierValue>> = 
+    signalsService.signal({} as any);
+  const isLoading: Signal<boolean> = signalsService.signal(false as any);
+  const error: Signal<string | null> = signalsService.signal(null as any);
+
+  // Extract modifiers from product
+  const modifiers = signalsService.computed(() => {
+    return (configProduct?.modifiers || []) as any;
+  }) as unknown as ReadOnlySignal<productsV3.ConnectedModifier[]>;
+
+  const hasModifiers: ReadOnlySignal<boolean> = signalsService.computed(() => {
+    const mods = modifiers.get();
+    return mods.length > 0;
+  });
+
+  const setModifierChoice = (modifierName: string, choiceValue: string) => {
+    const current = selectedModifiers.get();
+    selectedModifiers.set({
+      ...current,
+      [modifierName]: {
+        modifierName,
+        choiceValue,
+      },
+    });
+  };
+
+  const setModifierFreeText = (modifierName: string, freeTextValue: string) => {
+    const current = selectedModifiers.get();
+    selectedModifiers.set({
+      ...current,
+      [modifierName]: {
+        modifierName,
+        freeTextValue,
+      },
+    });
+  };
+
+  const clearModifier = (modifierName: string) => {
+    const current = selectedModifiers.get();
+    const updated = { ...current };
+    delete updated[modifierName];
+    selectedModifiers.set(updated);
+  };
+
+  const clearAllModifiers = () => {
+    selectedModifiers.set({});
+  };
+
+  const getModifierValue = (modifierName: string): ModifierValue | null => {
+    const current = selectedModifiers.get();
+    return current[modifierName] || null;
+  };
+
+  const isModifierRequired = (modifierName: string): boolean => {
+    const mods = modifiers.get();
+    const modifier = mods.find(m => m.name === modifierName);
+    return modifier?.mandatory || false;
+  };
+
+  const hasRequiredModifiers = (): boolean => {
+    const mods = modifiers.get();
+    return mods.some(m => m.mandatory);
+  };
+
+  const areAllRequiredModifiersFilled = (): boolean => {
+    const mods = modifiers.get();
+    const current = selectedModifiers.get();
+    
+    return mods.every(modifier => {
+      if (!modifier.mandatory) return true;
+      
+      const selectedValue = current[modifier.name || ""];
+      if (!selectedValue) return false;
+      
+      // Check based on modifier type
+      const renderType = modifier.modifierRenderType;
+      if (renderType === "SWATCH_CHOICES" || renderType === "TEXT_CHOICES") {
+        return !!selectedValue.choiceValue;
+      } else if (renderType === "FREE_TEXT") {
+        return !!selectedValue.freeTextValue && selectedValue.freeTextValue.trim() !== "";
+      }
+      
+      return false;
+    });
+  };
+
+  return {
+    modifiers,
+    selectedModifiers,
+    hasModifiers,
+    isLoading,
+    error,
+
+    setModifierChoice,
+    setModifierFreeText,
+    clearModifier,
+    clearAllModifiers,
+    getModifierValue,
+    isModifierRequired,
+    hasRequiredModifiers,
+    areAllRequiredModifiersFilled,
+  };
+});
+
+export function createProductModifiersServiceConfig(
+  product: productsV3.V3Product
+): ServiceFactoryConfig<typeof ProductModifiersService> {
+  return {
+    product,
+  };
+} 

--- a/src/pages/store/example-2/[slug].astro
+++ b/src/pages/store/example-2/[slug].astro
@@ -46,6 +46,18 @@ const relatedProductsServiceConfig = await loadRelatedProductsServiceConfig(
   productServiceConfig.product._id || "",
   4 // limit to 4 related products
 );
+
+// Load product modifiers service configuration if product has modifiers
+let productModifiersServiceConfig = null;
+try {
+  if (productServiceConfig.product.modifiers && productServiceConfig.product.modifiers.length > 0) {
+    productModifiersServiceConfig = {
+      product: productServiceConfig.product,
+    };
+  }
+} catch (error) {
+  console.warn("Could not load product modifiers service:", error);
+}
 ---
 
 <BaseLayout>
@@ -67,6 +79,7 @@ const relatedProductsServiceConfig = await loadRelatedProductsServiceConfig(
     selectedVariantServiceConfig={selectedVariantServiceConfig}
     socialSharingServiceConfig={socialSharingServiceConfig}
     relatedProductsServiceConfig={relatedProductsServiceConfig}
+    productModifiersServiceConfig={productModifiersServiceConfig}
     slot="body"
   />
 </BaseLayout>

--- a/src/react-pages/store/example-2/products/[slug].tsx
+++ b/src/react-pages/store/example-2/products/[slug].tsx
@@ -37,12 +37,17 @@ import {
   RelatedProductsService,
   loadRelatedProductsServiceConfig,
 } from "../../../../headless/store/services/related-products-service";
+import {
+  ProductModifiersServiceDefinition,
+  ProductModifiersService,
+} from "../../../../headless/store/services/product-modifiers-service";
 import { Product } from "../../../../headless/store/components/Product";
 import { ProductVariantSelector } from "../../../../headless/store/components/ProductVariantSelector";
 import { ProductMediaGallery } from "../../../../headless/store/components/ProductMediaGallery";
 import { CurrentCart } from "../../../../headless/store/components/CurrentCart";
 import { SocialSharing } from "../../../../headless/store/components/SocialSharing";
 import { RelatedProducts } from "../../../../headless/store/components/RelatedProducts";
+import { ProductModifiers } from "../../../../headless/store/components/ProductModifiers";
 import WixMediaImage from "../../../../headless/media/components/Image";
 
 interface ProductDetailPageProps {
@@ -52,6 +57,7 @@ interface ProductDetailPageProps {
   selectedVariantServiceConfig: any;
   socialSharingServiceConfig: any;
   relatedProductsServiceConfig: any;
+  productModifiersServiceConfig?: any;
 }
 
 const ProductImageGallery = () => {
@@ -525,6 +531,175 @@ const ProductInfo = ({ onAddToCart, servicesManager }: { onAddToCart: () => void
         )}
       </ProductVariantSelector.Options>
 
+      {/* Product Modifiers */}
+      <ProductModifiers.Modifiers>
+        {withDocsWrapper(
+          ({ modifiers, hasModifiers, selectedModifiers, areAllRequiredModifiersFilled }) => (
+            <>
+              {hasModifiers && (
+                <div className="space-y-6">
+                  <h3 className="text-lg font-semibold text-white">
+                    Product Customizations
+                  </h3>
+                  
+                  {modifiers.map((modifier: any) => (
+                    <div key={modifier.name}>
+                      <ProductModifiers.Modifier modifier={modifier}>
+                        {withDocsWrapper(
+                          ({ name, type, mandatory, choices, hasChoices, isFreeText, maxChars, placeholder }) => (
+                            <div className="space-y-3">
+                              <h4 className="text-md font-medium text-white">
+                                {name}
+                                {mandatory && <span className="text-red-400 ml-1">*</span>}
+                              </h4>
+                              
+                              {isFreeText ? (
+                                // FREE_TEXT modifier
+                                <div className="space-y-2">
+                                  {!mandatory ? (
+                                    // Optional free text with toggle
+                                    <ProductModifiers.ToggleFreeText modifier={modifier}>
+                                      {withDocsWrapper(
+                                        ({ isTextInputShown, onToggle, mandatory: toggleMandatory }) => (
+                                          <div className="space-y-3">
+                                            <label className="flex items-center gap-2">
+                                              <input
+                                                type="checkbox"
+                                                checked={isTextInputShown}
+                                                onChange={onToggle}
+                                                className="rounded border-white/20 bg-white/10 text-teal-500 focus:ring-teal-500"
+                                              />
+                                              <span className="text-white/80">Enable</span>
+                                            </label>
+                                            
+                                            {isTextInputShown && (
+                                              <ProductModifiers.FreeText modifier={modifier}>
+                                                {withDocsWrapper(
+                                                  ({ value, onChange, charCount, isOverLimit, maxChars: textMaxChars, placeholder: freeTextPlaceholder }) => (
+                                                    <div className="space-y-1">
+                                                      <textarea
+                                                        value={value}
+                                                        onChange={(e) => onChange(e.target.value)}
+                                                        placeholder={freeTextPlaceholder || `Enter your ${name.toLowerCase()}...`}
+                                                        maxLength={textMaxChars}
+                                                        className="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/50 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 resize-none"
+                                                        rows={3}
+                                                      />
+                                                      {textMaxChars && (
+                                                        <p className={`text-xs text-right ${isOverLimit ? 'text-red-400' : 'text-white/60'}`}>
+                                                          {charCount}/{textMaxChars}
+                                                        </p>
+                                                      )}
+                                                    </div>
+                                                  ),
+                                                  "ProductModifiers.FreeText",
+                                                  "/docs/components/product-modifiers#free-text"
+                                                )}
+                                              </ProductModifiers.FreeText>
+                                            )}
+                                          </div>
+                                        ),
+                                        "ProductModifiers.ToggleFreeText",
+                                        "/docs/components/product-modifiers#toggle-free-text"
+                                      )}
+                                    </ProductModifiers.ToggleFreeText>
+                                  ) : (
+                                    // Mandatory free text (always shown)
+                                    <ProductModifiers.FreeText modifier={modifier}>
+                                      {withDocsWrapper(
+                                        ({ value, onChange, charCount, isOverLimit, maxChars: textMaxChars, placeholder: freeTextPlaceholder }) => (
+                                          <div className="space-y-1">
+                                            <textarea
+                                              value={value}
+                                              onChange={(e) => onChange(e.target.value)}
+                                              placeholder={freeTextPlaceholder || `Enter your ${name.toLowerCase()}...`}
+                                              maxLength={textMaxChars}
+                                              className="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/50 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 resize-none"
+                                              rows={3}
+                                            />
+                                            {textMaxChars && (
+                                              <p className={`text-xs text-right ${isOverLimit ? 'text-red-400' : 'text-white/60'}`}>
+                                                {charCount}/{textMaxChars}
+                                              </p>
+                                            )}
+                                          </div>
+                                        ),
+                                        "ProductModifiers.FreeText",
+                                        "/docs/components/product-modifiers#free-text"
+                                      )}
+                                    </ProductModifiers.FreeText>
+                                  )}
+                                </div>
+                              ) : hasChoices ? (
+                                // SWATCH_CHOICES or TEXT_CHOICES modifier
+                                <div className="flex flex-wrap gap-3">
+                                  {choices.map((choice: any, choiceIndex: number) => {
+                                    const isColorModifier = type === "SWATCH_CHOICES";
+                                    const hasColorCode = choice.colorCode;
+
+                                    return (
+                                      <ProductModifiers.Choice
+                                        key={choiceIndex}
+                                        modifier={modifier}
+                                        choice={choice}
+                                      >
+                                        {withDocsWrapper(
+                                          ({ value, isSelected, onSelect, colorCode }) => (
+                                            <>
+                                              {isColorModifier && hasColorCode ? (
+                                                // Color Swatch for modifiers
+                                                <button
+                                                  onClick={onSelect}
+                                                  title={value}
+                                                  className={`w-10 h-10 rounded-full border-4 transition-all duration-200 ${
+                                                    isSelected
+                                                      ? "border-teal-400 shadow-lg scale-110 ring-2 ring-teal-500/30"
+                                                      : "border-white/30 hover:border-white/60 hover:scale-105"
+                                                  }`}
+                                                  style={{
+                                                    backgroundColor: colorCode || "#000000",
+                                                  }}
+                                                />
+                                              ) : (
+                                                // Regular Text Button for modifiers
+                                                <button
+                                                  onClick={onSelect}
+                                                  className={`px-4 py-2 rounded-lg border transition-all ${
+                                                    isSelected
+                                                      ? "bg-teal-500 border-teal-500 text-white ring-2 ring-teal-500/30"
+                                                      : "bg-white/5 border-white/20 text-white hover:border-white/40 hover:bg-white/10"
+                                                  }`}
+                                                >
+                                                  {value}
+                                                </button>
+                                              )}
+                                            </>
+                                          ),
+                                          "ProductModifiers.Choice",
+                                          "/docs/components/product-modifiers#choice"
+                                        )}
+                                      </ProductModifiers.Choice>
+                                    );
+                                  })}
+                                </div>
+                              ) : null}
+                            </div>
+                          ),
+                          "ProductModifiers.Modifier",
+                          "/docs/components/product-modifiers#modifier"
+                        )}
+                      </ProductModifiers.Modifier>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          ),
+          "ProductModifiers.Modifiers",
+          "/docs/components/product-modifiers#modifiers"
+        )}
+      </ProductModifiers.Modifiers>
+
       <div className="space-y-3">
         <h3 className="text-lg font-semibold text-white">Quantity</h3>
         <div className="flex items-center gap-3">
@@ -948,42 +1123,52 @@ export default function ProductDetailPage({
   selectedVariantServiceConfig,
   socialSharingServiceConfig,
   relatedProductsServiceConfig,
+  productModifiersServiceConfig,
 }: ProductDetailPageProps) {
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
 
-  const servicesManager = createServicesManager(
-    createServicesMap()
-      .addService(
-        ProductServiceDefinition,
-        ProductService,
-        productServiceConfig
-      )
-      .addService(
-        CurrentCartServiceDefinition,
-        CurrentCartService,
-        currentCartServiceConfig
-      )
-      .addService(
-        SelectedVariantServiceDefinition,
-        SelectedVariantService,
-        selectedVariantServiceConfig
-      )
-      .addService(
-        ProductMediaGalleryServiceDefinition,
-        ProductMediaGalleryService,
-        productMediaGalleryServiceConfig
-      )
-      .addService(
-        SocialSharingServiceDefinition,
-        SocialSharingService,
-        socialSharingServiceConfig
-      )
-      .addService(
-        RelatedProductsServiceDefinition,
-        RelatedProductsService,
-        relatedProductsServiceConfig
-      )
-  );
+  let servicesMap = createServicesMap()
+    .addService(
+      ProductServiceDefinition,
+      ProductService,
+      productServiceConfig
+    )
+    .addService(
+      CurrentCartServiceDefinition,
+      CurrentCartService,
+      currentCartServiceConfig
+    )
+    .addService(
+      SelectedVariantServiceDefinition,
+      SelectedVariantService,
+      selectedVariantServiceConfig
+    )
+    .addService(
+      ProductMediaGalleryServiceDefinition,
+      ProductMediaGalleryService,
+      productMediaGalleryServiceConfig
+    )
+    .addService(
+      SocialSharingServiceDefinition,
+      SocialSharingService,
+      socialSharingServiceConfig
+    )
+    .addService(
+      RelatedProductsServiceDefinition,
+      RelatedProductsService,
+      relatedProductsServiceConfig
+    );
+
+  // Add product modifiers service if available
+  if (productModifiersServiceConfig) {
+    servicesMap = servicesMap.addService(
+      ProductModifiersServiceDefinition,
+      ProductModifiersService,
+      productModifiersServiceConfig
+    );
+  }
+
+  const servicesManager = createServicesManager(servicesMap);
 
   return (
     <KitchensinkLayout>


### PR DESCRIPTION
- Created ProductModifiersService for managing modifier state
- Added ProductModifiers headless component with support for:
  - SWATCH_CHOICES and TEXT_CHOICES modifiers
  - FREE_TEXT modifiers with optional toggle
  - Mandatory vs optional modifier handling
- Updated product pages to include modifier support
- Made modifier service optional to handle products without modifiers
- Updated ProductVariantSelector to include modifier data in cart