### PR TITLE
fix: broken buy button

### DIFF
--- a/src/components/store/ProductActionButtons.tsx
+++ b/src/components/store/ProductActionButtons.tsx
@@ -91,11 +91,10 @@ const BuyNowButton: React.FC<BuyNowButtonProps> = ({
   onAddToCart,
   className = "",
 }) => {
+  const cartService = useService(CurrentCartServiceDefinition);
+  
   const handleBuyNow = async () => {
     try {
-      const cartService = useService(
-        CurrentCartServiceDefinition
-      );
       await cartService.clearCart();
       await onAddToCart();
       await cartService.proceedToCheckout();


### PR DESCRIPTION
The buy button wasn't working because of a React hook violation in the BuyNowButton component. The code was calling useService(CurrentCartServiceDefinition) inside an async function, which violates React's "Rules of Hooks" - hooks must be called at the top level of function components, not inside nested functions.