### PR TITLE
fix: use union logic to show all available choices before selecting a variant

### DIFF
--- a/src/headless/store/services/selected-variant-service.ts
+++ b/src/headless/store/services/selected-variant-service.ts
@@ -617,7 +617,7 @@ export const SelectedVariantService = implementService.withConfig<{}>()(
 
       // Get all variants and find one that matches these choices
       const variantsList = variants.get();
-      const matchingVariant = variantsList.find(variant => {
+      const matchingVariants = variantsList.filter(variant => {
         if (!variant.choices) return false;
 
         const variantChoices: Record<string, string> = {};
@@ -637,10 +637,15 @@ export const SelectedVariantService = implementService.withConfig<{}>()(
         );
       });
 
-      const isAvailable = !!matchingVariant;
-      const isInStock = matchingVariant?.inventoryStatus?.inStock === true;
+      const isAvailable = matchingVariants.length > 0;
+
+      const isInStock = matchingVariants.some(
+        variant => variant.inventoryStatus?.inStock === true
+      );
+
+      const firstMatchingVariant = matchingVariants[0];
       const isPreOrderEnabled =
-        matchingVariant?.inventoryStatus?.preorderEnabled === true;
+        firstMatchingVariant?.inventoryStatus?.preorderEnabled === true;
 
       return { isAvailable, isInStock, isPreOrderEnabled };
     };


### PR DESCRIPTION
This PR fixes the following issue: 
<img width="431" alt="image" src="https://github.com/user-attachments/assets/4d243461-5b7f-4c63-ab99-71b35ae1d69d" />
