### PR TITLE
fix: use union logic to show all available choices before selecting a variant 

### DIFF
--- a/src/headless/store/services/selected-variant-service.ts
+++ b/src/headless/store/services/selected-variant-service.ts
@@ -638,15 +638,15 @@ export const SelectedVariantService = implementService.withConfig<{}>()(
         );
       });
 
-              const isAvailable = matchingVariants.length > 0;
-        // Check if ANY of the matching variants are in stock
-        const isInStock = matchingVariants.some(
-          variant => variant.inventoryStatus?.inStock === true
-        );
-        // Check if ANY of the matching variants have pre-order enabled
-        const isPreOrderEnabled = matchingVariants.some(
-          variant => variant.inventoryStatus?.preorderEnabled === true
-        );
+      const isAvailable = matchingVariants.length > 0;
+      // Check if ANY of the matching variants are in stock
+      const isInStock = matchingVariants.some(
+        variant => variant.inventoryStatus?.inStock === true
+      );
+      // Check if ANY of the matching variants have pre-order enabled
+      const isPreOrderEnabled = matchingVariants.some(
+        variant => variant.inventoryStatus?.preorderEnabled === true
+      );
 
       return { isAvailable, isInStock, isPreOrderEnabled };
     };

--- a/src/headless/store/services/selected-variant-service.ts
+++ b/src/headless/store/services/selected-variant-service.ts
@@ -638,15 +638,15 @@ export const SelectedVariantService = implementService.withConfig<{}>()(
         );
       });
 
-      const isAvailable = matchingVariants.length > 0;
-
-      const isInStock = matchingVariants.some(
-        variant => variant.inventoryStatus?.inStock === true
-      );
-
-      const firstMatchingVariant = matchingVariants[0];
-      const isPreOrderEnabled =
-        firstMatchingVariant?.inventoryStatus?.preorderEnabled === true;
+              const isAvailable = matchingVariants.length > 0;
+        // Check if ANY of the matching variants are in stock
+        const isInStock = matchingVariants.some(
+          variant => variant.inventoryStatus?.inStock === true
+        );
+        // Check if ANY of the matching variants have pre-order enabled
+        const isPreOrderEnabled = matchingVariants.some(
+          variant => variant.inventoryStatus?.preorderEnabled === true
+        );
 
       return { isAvailable, isInStock, isPreOrderEnabled };
     };


### PR DESCRIPTION
This PR fixes the following issue:
<img width="438" alt="image" src="https://github.com/user-attachments/assets/bcec7ef2-f9ec-4b3a-b87b-9bcf44b57506" />
