### PR TITLE
Services cleanup

### DIFF
--- a/src/headless/store/services/catalog-service.ts
+++ b/src/headless/store/services/catalog-service.ts
@@ -1,0 +1,302 @@
+import {
+  defineService,
+  implementService,
+  type ServiceFactoryConfig,
+} from '@wix/services-definitions';
+import { SignalsServiceDefinition } from '@wix/services-definitions/core-services/signals';
+import type { Signal } from '@wix/services-definitions/core-services/signals';
+import { productsV3, customizationsV3 } from '@wix/stores';
+
+const { SortDirection, SortType: SDKSortType } = productsV3;
+
+export interface ProductOption {
+  id: string;
+  name: string;
+  choices: ProductChoice[];
+  optionRenderType?: string;
+}
+
+export interface ProductChoice {
+  id: string;
+  name: string;
+  colorCode?: string;
+}
+
+export interface CatalogPriceRange {
+  minPrice: number;
+  maxPrice: number;
+}
+
+export interface CatalogServiceAPI {
+  catalogOptions: Signal<ProductOption[] | null>;
+  catalogPriceRange: Signal<CatalogPriceRange | null>;
+  isLoading: Signal<boolean>;
+  error: Signal<string | null>;
+  loadCatalogData: (categoryId?: string) => Promise<void>;
+}
+
+// Helper functions
+const extractAggregationValues = (
+  aggregationResponse: any,
+  name: string
+): string[] => {
+  const aggregation =
+    aggregationResponse.aggregations?.[name] ||
+    aggregationResponse.aggregationData?.results?.find(
+      (r: any) => r.name === name
+    );
+  return aggregation?.values?.results?.map((item: any) => item.value) || [];
+};
+
+const extractScalarAggregationValue = (
+  aggregationResponse: any,
+  name: string
+): number | null => {
+  const aggregation =
+    aggregationResponse.aggregations?.[name] ||
+    aggregationResponse.aggregationData?.results?.find(
+      (r: any) => r.name === name
+    );
+  const value = aggregation?.scalar?.value;
+  return value !== undefined && value !== null ? parseFloat(value) : null;
+};
+
+const matchesAggregationName = (
+  name: string,
+  aggregationNames: string[]
+): boolean => {
+  return aggregationNames.some(
+    aggName => aggName.toLowerCase() === name.toLowerCase()
+  );
+};
+
+const sortChoicesIntelligently = (
+  choices: ProductChoice[]
+): ProductChoice[] => {
+  return [...choices].sort((a, b) => {
+    const aIsNumber = /^\d+$/.test(a.name);
+    const bIsNumber = /^\d+$/.test(b.name);
+
+    if (aIsNumber && bIsNumber) {
+      return parseInt(b.name) - parseInt(a.name);
+    }
+    if (aIsNumber && !bIsNumber) return -1;
+    if (!aIsNumber && bIsNumber) return 1;
+
+    return a.name.localeCompare(b.name);
+  });
+};
+
+const buildCategoryFilter = (categoryId?: string) => {
+  if (!categoryId) {
+    return { visible: true };
+  }
+
+  return {
+    visible: true,
+    'allCategoriesInfo.categories': {
+      $matchItems: [{ _id: { $in: [categoryId] } }],
+    },
+  };
+};
+
+export const CatalogServiceDefinition =
+  defineService<CatalogServiceAPI>('catalog');
+
+export const CatalogService = implementService.withConfig<{}>()(
+  CatalogServiceDefinition,
+  ({ getService }) => {
+    const signalsService = getService(SignalsServiceDefinition);
+
+    const catalogOptions: Signal<ProductOption[] | null> =
+      signalsService.signal(null as any);
+    const catalogPriceRange: Signal<CatalogPriceRange | null> =
+      signalsService.signal(null as any);
+    const isLoading: Signal<boolean> = signalsService.signal(false as any);
+    const error: Signal<string | null> = signalsService.signal(null as any);
+
+    const loadCatalogData = async (categoryId?: string): Promise<void> => {
+      isLoading.set(true);
+      error.set(null);
+
+      try {
+        // Single aggregation request to get ALL catalog data at once
+        const aggregationRequest = {
+          aggregations: [
+            // Price range aggregations
+            {
+              name: 'minPrice',
+              fieldPath: 'actualPriceRange.minValue.amount',
+              type: 'SCALAR' as const,
+              scalar: { type: 'MIN' as const },
+            },
+            {
+              name: 'maxPrice',
+              fieldPath: 'actualPriceRange.maxValue.amount',
+              type: 'SCALAR' as const,
+              scalar: { type: 'MAX' as const },
+            },
+            // Options aggregations
+            {
+              name: 'optionNames',
+              fieldPath: 'options.name',
+              type: SDKSortType.VALUE,
+              value: {
+                limit: 20,
+                sortType: SDKSortType.VALUE,
+                sortDirection: SortDirection.ASC,
+              },
+            },
+            {
+              name: 'choiceNames',
+              fieldPath: 'options.choicesSettings.choices.name',
+              type: SDKSortType.VALUE,
+              value: {
+                limit: 50,
+                sortType: SDKSortType.VALUE,
+                sortDirection: SortDirection.ASC,
+              },
+            },
+            {
+              name: 'inventoryStatus',
+              fieldPath: 'inventory.availabilityStatus',
+              type: SDKSortType.VALUE,
+              value: {
+                limit: 10,
+                sortType: SDKSortType.VALUE,
+                sortDirection: SortDirection.ASC,
+              },
+            },
+          ],
+          filter: buildCategoryFilter(categoryId),
+          includeProducts: false,
+          cursorPaging: { limit: 0 },
+        };
+
+        // Make the single aggregation request
+        const [aggregationResponse, customizationsResponse] = await Promise.all(
+          [
+            productsV3.searchProducts(aggregationRequest as any),
+            customizationsV3.queryCustomizations().find(),
+          ]
+        );
+
+        // Process price range data
+        const minPrice = extractScalarAggregationValue(
+          aggregationResponse,
+          'minPrice'
+        );
+        const maxPrice = extractScalarAggregationValue(
+          aggregationResponse,
+          'maxPrice'
+        );
+
+        if (
+          minPrice !== null &&
+          maxPrice !== null &&
+          (minPrice > 0 || maxPrice > 0)
+        ) {
+          catalogPriceRange.set({
+            minPrice,
+            maxPrice,
+          });
+        } else {
+          catalogPriceRange.set(null);
+        }
+
+        // Process options data
+        const optionNames = extractAggregationValues(
+          aggregationResponse,
+          'optionNames'
+        );
+        const choiceNames = extractAggregationValues(
+          aggregationResponse,
+          'choiceNames'
+        );
+        const inventoryStatuses = extractAggregationValues(
+          aggregationResponse,
+          'inventoryStatus'
+        );
+
+        const customizations = customizationsResponse.items || [];
+
+        // Build options by matching customizations with aggregation data
+        const options: ProductOption[] = customizations
+          .filter(
+            customization =>
+              customization.name &&
+              customization._id &&
+              customization.customizationType ===
+                customizationsV3.CustomizationType.PRODUCT_OPTION &&
+              matchesAggregationName(customization.name, optionNames)
+          )
+          .map(customization => {
+            const choices: ProductChoice[] = (
+              customization.choicesSettings?.choices || []
+            )
+              .filter(
+                choice =>
+                  choice._id &&
+                  choice.name &&
+                  matchesAggregationName(choice.name, choiceNames)
+              )
+              .map(choice => ({
+                id: choice._id!,
+                name: choice.name!,
+                colorCode: choice.colorCode,
+              }));
+
+            return {
+              id: customization._id!,
+              name: customization.name!,
+              choices: sortChoicesIntelligently(choices),
+              optionRenderType: customization.customizationRenderType,
+            };
+          })
+          .filter(option => option.choices.length > 0);
+
+        // Add inventory filter if there are multiple inventory statuses
+        if (inventoryStatuses.length > 1) {
+          const inventoryChoices: ProductChoice[] = inventoryStatuses.map(
+            status => ({
+              id: status.toUpperCase(),
+              name: status.toUpperCase(),
+            })
+          );
+
+          options.push({
+            id: 'inventory-filter',
+            name: 'Availability',
+            choices: inventoryChoices,
+            optionRenderType: productsV3.ModifierRenderType.TEXT_CHOICES,
+          });
+        }
+
+        catalogOptions.set(options);
+      } catch (err) {
+        console.error('Failed to load catalog data:', err);
+        error.set(
+          err instanceof Error ? err.message : 'Failed to load catalog data'
+        );
+        catalogOptions.set([]);
+        catalogPriceRange.set(null);
+      } finally {
+        isLoading.set(false);
+      }
+    };
+
+    return {
+      catalogOptions,
+      catalogPriceRange,
+      isLoading,
+      error,
+      loadCatalogData,
+    };
+  }
+);
+
+export async function loadCatalogServiceConfig(): Promise<
+  ServiceFactoryConfig<typeof CatalogService>
+> {
+  return {};
+}

--- a/src/headless/store/services/collection-service.ts
+++ b/src/headless/store/services/collection-service.ts
@@ -1,0 +1,711 @@
+import {
+  defineService,
+  implementService,
+  type ServiceFactoryConfig,
+} from '@wix/services-definitions';
+import { SignalsServiceDefinition } from '@wix/services-definitions/core-services/signals';
+import type { Signal } from '@wix/services-definitions/core-services/signals';
+
+import { productsV3, readOnlyVariantsV3 } from '@wix/stores';
+import { FilterServiceDefinition, type Filter } from './filter-service';
+import { CategoryServiceDefinition } from './category-service';
+import { SortServiceDefinition, type SortBy } from './sort-service';
+import { CatalogServiceDefinition } from './catalog-service';
+import { URLParamsUtils } from '../utils/url-params';
+import { SortType } from '../enums/sort-enums';
+
+const { SortDirection } = productsV3;
+
+const searchProducts = async (searchOptions: any) => {
+  const searchParams = {
+    filter: searchOptions.search?.filter,
+    sort: searchOptions.search?.sort,
+    ...(searchOptions.paging && { cursorPaging: searchOptions.paging }),
+  };
+
+  const options = {
+    fields: searchOptions.fields || [],
+  };
+
+  const result = await productsV3.searchProducts(searchParams, options);
+
+  // Fetch missing variants for all products in one batch request
+  if (result.products) {
+    result.products = await fetchMissingVariants(result.products);
+  }
+
+  return result;
+};
+
+export interface CollectionServiceAPI {
+  products: Signal<productsV3.V3Product[]>;
+  isLoading: Signal<boolean>;
+  error: Signal<string | null>;
+  totalProducts: Signal<number>;
+  hasProducts: Signal<boolean>;
+  hasMoreProducts: Signal<boolean>;
+  loadMore: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+// Helper to build search options with supported filters
+const buildSearchOptions = (
+  filters?: Filter,
+  selectedCategory?: string | null,
+  sortBy?: SortBy
+) => {
+  const searchOptions: any = {
+    search: {},
+    fields: [
+      'DESCRIPTION' as any,
+      'DIRECT_CATEGORIES_INFO' as any,
+      'BREADCRUMBS_INFO' as any,
+      'INFO_SECTION' as any,
+      'MEDIA_ITEMS_INFO' as any,
+      'PLAIN_DESCRIPTION' as any,
+      'THUMBNAIL' as any,
+      'URL' as any,
+      'VARIANT_OPTION_CHOICE_NAMES' as any,
+      'WEIGHT_MEASUREMENT_UNIT_INFO' as any,
+    ],
+  };
+
+  // Build filter conditions array
+  const filterConditions: any[] = [];
+
+  // Add category filter if selected
+  if (selectedCategory) {
+    filterConditions.push({
+      'allCategoriesInfo.categories': {
+        $matchItems: [
+          {
+            id: {
+              $in: [selectedCategory],
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  // Add price range filter if provided
+  if (filters?.priceRange) {
+    const { min, max } = filters.priceRange;
+    if (min > 0) {
+      filterConditions.push({
+        'actualPriceRange.minValue.amount': { $gte: min.toString() },
+      });
+    }
+    if (max > 0 && max < 999999) {
+      filterConditions.push({
+        'actualPriceRange.maxValue.amount': { $lte: max.toString() },
+      });
+    }
+  }
+
+  // Add product options filter if provided
+  if (
+    filters?.selectedOptions &&
+    Object.keys(filters.selectedOptions).length > 0
+  ) {
+    for (const [optionId, choiceIds] of Object.entries(
+      filters.selectedOptions
+    )) {
+      if (choiceIds.length > 0) {
+        // Handle inventory filter separately
+        if (optionId === 'inventory-filter') {
+          filterConditions.push({
+            'inventory.availabilityStatus': {
+              $in: choiceIds,
+            },
+          });
+        } else {
+          // Regular product options filter
+          filterConditions.push({
+            'options.choicesSettings.choices.choiceId': {
+              $hasSome: choiceIds,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  // Apply filters
+  if (filterConditions.length > 0) {
+    if (filterConditions.length === 1) {
+      // Single condition - no need for $and wrapper
+      searchOptions.search.filter = filterConditions[0];
+    } else {
+      // Multiple conditions - use $and
+      searchOptions.search.filter = {
+        $and: filterConditions,
+      };
+    }
+  }
+
+  // Add sort if provided
+  if (sortBy) {
+    switch (sortBy) {
+      case SortType.NAME_ASC:
+        searchOptions.search.sort = [
+          { fieldName: 'name', order: SortDirection.ASC },
+        ];
+        break;
+      case SortType.NAME_DESC:
+        searchOptions.search.sort = [
+          { fieldName: 'name', order: SortDirection.DESC },
+        ];
+        break;
+      case SortType.PRICE_ASC:
+        searchOptions.search.sort = [
+          {
+            fieldName: 'actualPriceRange.minValue.amount',
+            order: SortDirection.ASC,
+          },
+        ];
+        break;
+      case SortType.PRICE_DESC:
+        searchOptions.search.sort = [
+          {
+            fieldName: 'actualPriceRange.minValue.amount',
+            order: SortDirection.DESC,
+          },
+        ];
+        break;
+      case SortType.RECOMMENDED:
+        searchOptions.search.sort = [
+          {
+            fieldName: 'allCategoriesInfo.categories.index',
+            selectItemsBy: [
+              {
+                'allCategoriesInfo.categories.id': selectedCategory,
+              },
+            ],
+          },
+        ];
+        break;
+    }
+  }
+
+  return searchOptions;
+};
+
+export const CollectionServiceDefinition =
+  defineService<CollectionServiceAPI>('collection');
+
+export const CollectionService = implementService.withConfig<{
+  initialProducts?: productsV3.V3Product[];
+  pageSize?: number;
+  initialCursor?: string;
+  initialHasMore?: boolean;
+  categories?: any[];
+}>()(CollectionServiceDefinition, ({ getService, config }) => {
+  const signalsService = getService(SignalsServiceDefinition);
+  const collectionFilters = getService(FilterServiceDefinition);
+  const categoryService = getService(CategoryServiceDefinition);
+  const sortService = getService(SortServiceDefinition);
+  const catalogService = getService(CatalogServiceDefinition);
+
+  const hasMoreProducts: Signal<boolean> = signalsService.signal(
+    (config.initialHasMore ?? true) as any
+  );
+  let nextCursor: string | undefined = config.initialCursor;
+
+  const initialProducts = config.initialProducts || [];
+
+  // Signal declarations
+  const productsList: Signal<productsV3.V3Product[]> = signalsService.signal(
+    initialProducts as any
+  );
+  const isLoading: Signal<boolean> = signalsService.signal(false as any);
+  const error: Signal<string | null> = signalsService.signal(null as any);
+  const totalProducts: Signal<number> = signalsService.signal(
+    initialProducts.length as any
+  );
+  const hasProducts: Signal<boolean> = signalsService.signal(
+    (initialProducts.length > 0) as any
+  );
+
+  const pageSize = config.pageSize || 12;
+  let allProducts: productsV3.V3Product[] = initialProducts;
+
+  // Debouncing mechanism to prevent multiple simultaneous refreshes
+  let refreshTimeout: NodeJS.Timeout | null = null;
+  let isRefreshing = false;
+  let isInitializingCatalogData = true;
+
+  const loadMore = async () => {
+    // Don't load more if there are no more products available
+    if (!hasMoreProducts.get()) {
+      return;
+    }
+
+    try {
+      isLoading.set(true);
+      error.set(null);
+
+      // For loadMore, use no filters or sorting to work with cursor pagination
+      const searchOptions = buildSearchOptions(undefined, undefined, undefined);
+
+      // Add pagination
+      searchOptions.paging = { limit: pageSize };
+      if (nextCursor) {
+        searchOptions.paging.cursor = nextCursor;
+      }
+
+      const currentProducts = productsList.get();
+      const productResults = await searchProducts(searchOptions);
+
+      // Update cursor for next pagination
+      nextCursor = productResults.pagingMetadata?.cursors?.next || undefined;
+
+      // Check if there are more products to load
+      const hasMore = Boolean(
+        nextCursor &&
+          productResults.products &&
+          productResults.products.length === pageSize
+      );
+      hasMoreProducts.set(hasMore);
+
+      // Update allProducts with the new data
+      allProducts = [...allProducts, ...(productResults.products || [])];
+
+      // Add new products to the list
+      const additionalProducts = productResults.products || [];
+      productsList.set([...currentProducts, ...additionalProducts]);
+      totalProducts.set(currentProducts.length + additionalProducts.length);
+      hasProducts.set(currentProducts.length + additionalProducts.length > 0);
+    } catch (err) {
+      error.set(
+        err instanceof Error ? err.message : 'Failed to load more products'
+      );
+    } finally {
+      isLoading.set(false);
+    }
+  };
+
+  const refresh = async (setTotalProducts: boolean = true) => {
+    if (isRefreshing) return;
+
+    try {
+      isRefreshing = true;
+      isLoading.set(true);
+      error.set(null);
+
+      const filters = collectionFilters.currentFilters.get();
+      const selectedCategory = categoryService.selectedCategory.get();
+      const sortBy = sortService.currentSort.get();
+
+      // Use regular search for all sorting options including recommended
+      const searchOptions = buildSearchOptions(
+        filters,
+        selectedCategory,
+        sortBy
+      );
+
+      // Add pagination
+      searchOptions.paging = { limit: pageSize };
+
+      const productResults = await searchProducts(searchOptions);
+      const isPriceSort =
+        sortBy === SortType.PRICE_ASC || sortBy === SortType.PRICE_DESC;
+      if (isPriceSort) {
+        productResults.products = productResults.products?.sort((a, b) => {
+          const aPrice = Number(a.actualPriceRange?.minValue?.amount) || 0;
+          const bPrice = Number(b.actualPriceRange?.minValue?.amount) || 0;
+          return sortBy === SortType.PRICE_ASC
+            ? aPrice - bPrice
+            : bPrice - aPrice;
+        });
+      }
+
+      // Reset pagination state
+      nextCursor = productResults.pagingMetadata?.cursors?.next || undefined;
+      const hasMore = Boolean(
+        productResults.pagingMetadata?.cursors?.next &&
+          productResults.products &&
+          productResults.products.length === pageSize
+      );
+      hasMoreProducts.set(hasMore);
+
+      // Update allProducts with the new data
+      allProducts = productResults.products || [];
+
+      // All filtering is handled server-side
+      productsList.set(allProducts);
+      if (setTotalProducts) {
+        totalProducts.set(allProducts.length);
+      }
+
+      hasProducts.set(allProducts.length > 0);
+    } catch (err) {
+      error.set(
+        err instanceof Error ? err.message : 'Failed to refresh products'
+      );
+    } finally {
+      isLoading.set(false);
+      isRefreshing = false;
+    }
+  };
+
+  // Debounced refresh function
+  const debouncedRefresh = async (
+    setTotalProducts: boolean = true
+  ): Promise<void> => {
+    if (refreshTimeout) {
+      clearTimeout(refreshTimeout);
+    }
+
+    return new Promise<void>(resolve => {
+      refreshTimeout = setTimeout(async () => {
+        await refresh(setTotalProducts);
+        resolve();
+      }, 50); // 50ms debounce delay
+    });
+  };
+
+  // Refresh with server-side filtering when any filters change
+  signalsService.effect(() => {
+    collectionFilters.currentFilters.get();
+    // Skip refresh during catalog data initialization to prevent double API calls
+    if (isInitializingCatalogData) {
+      return;
+    }
+    // All filtering (categories, price, options) is now handled server-side
+    debouncedRefresh(false);
+  });
+
+  // Initialize catalog data when the service starts
+  const initializeCatalogData = async () => {
+    isInitializingCatalogData = true; // Set flag BEFORE loading
+    const selectedCategory = categoryService.selectedCategory.get();
+
+    // Load catalog data from the combined catalog service
+    await catalogService.loadCatalogData(selectedCategory || undefined);
+
+    // Reset flag to allow filter changes to trigger refreshes
+    isInitializingCatalogData = false;
+  };
+
+  signalsService.effect(() => {
+    sortService.currentSort.get();
+    debouncedRefresh(false);
+  });
+
+  signalsService.effect(() => {
+    categoryService.selectedCategory.get();
+    debouncedRefresh(true).then(async () => {
+      await initializeCatalogData();
+    });
+  });
+
+  return {
+    products: productsList,
+    isLoading,
+    error,
+    totalProducts,
+    hasProducts,
+    hasMoreProducts,
+    loadMore,
+    refresh: debouncedRefresh,
+  };
+});
+
+// Helper function to parse URL parameters
+function parseURLParams(
+  searchParams?: URLSearchParams,
+  products: productsV3.V3Product[] = []
+) {
+  const defaultFilters: Filter = {
+    priceRange: { min: 0, max: 0 },
+    selectedOptions: {},
+  };
+
+  if (!searchParams) {
+    return {
+      initialSort: SortType.NEWEST as SortBy,
+      initialFilters: defaultFilters,
+    };
+  }
+
+  const urlParams = URLParamsUtils.parseSearchParams(searchParams);
+
+  // Parse sort parameter
+  const sortMap: Record<string, SortBy> = {
+    name_asc: SortType.NAME_ASC,
+    name_desc: SortType.NAME_DESC,
+    price_asc: SortType.PRICE_ASC,
+    price_desc: SortType.PRICE_DESC,
+    recommended: SortType.RECOMMENDED,
+  };
+  const initialSort =
+    sortMap[urlParams.sort as string] || (SortType.NEWEST as SortBy);
+
+  // Check if there are any filter parameters (excluding sort)
+  const filterParams = Object.keys(urlParams).filter(key => key !== 'sort');
+
+  if (filterParams.length === 0 || products.length === 0) {
+    return { initialSort, initialFilters: defaultFilters };
+  }
+
+  // Calculate available price range from products
+  const priceRange = calculatePriceRange(products);
+  const initialFilters: Filter = {
+    priceRange,
+    selectedOptions: {},
+  };
+
+  // Apply price filters from URL
+  if (urlParams.minPrice) {
+    const min = parseFloat(urlParams.minPrice as string);
+    if (!isNaN(min)) initialFilters.priceRange.min = min;
+  }
+  if (urlParams.maxPrice) {
+    const max = parseFloat(urlParams.maxPrice as string);
+    if (!isNaN(max)) initialFilters.priceRange.max = max;
+  }
+
+  // Parse option filters
+  const optionsMap = buildOptionsMap(products);
+  parseOptionFilters(urlParams, optionsMap, initialFilters);
+
+  // Parse inventory filter from 'availability' URL parameter
+  if (urlParams.availability) {
+    const availabilityValues = Array.isArray(urlParams.availability)
+      ? urlParams.availability
+      : [urlParams.availability];
+
+    const inventoryStatusValues = availabilityValues.map(value =>
+      value.replace(/\s+/g, '_').toUpperCase()
+    );
+
+    initialFilters.selectedOptions['inventory-filter'] = inventoryStatusValues;
+  }
+
+  return { initialSort, initialFilters };
+}
+
+// Helper function to calculate price range from products
+function calculatePriceRange(products: productsV3.V3Product[]): {
+  min: number;
+  max: number;
+} {
+  if (products.length === 0) {
+    return { min: 0, max: 1000 };
+  }
+
+  let minPrice = Infinity;
+  let maxPrice = 0;
+
+  products.forEach(product => {
+    const min = parseFloat(product.actualPriceRange?.minValue?.amount || '0');
+    const max = parseFloat(product.actualPriceRange?.maxValue?.amount || '0');
+    if (min > 0) minPrice = Math.min(minPrice, min);
+    if (max > 0) maxPrice = Math.max(maxPrice, max);
+  });
+
+  // If no valid prices found, return default range
+  if (minPrice === Infinity) {
+    minPrice = 0;
+    maxPrice = 1000;
+  }
+
+  return { min: minPrice, max: maxPrice };
+}
+
+// Helper function to build options map from products
+function buildOptionsMap(products: productsV3.V3Product[]) {
+  const optionsMap = new Map<
+    string,
+    { id: string; choices: { id: string; name: string }[] }
+  >();
+
+  products.forEach(product => {
+    product.options?.forEach(option => {
+      if (!option._id || !option.name) return;
+
+      if (!optionsMap.has(option.name)) {
+        optionsMap.set(option.name, { id: option._id, choices: [] });
+      }
+
+      const optionData = optionsMap.get(option.name)!;
+      option.choicesSettings?.choices?.forEach(choice => {
+        if (
+          choice.choiceId &&
+          choice.name &&
+          !optionData.choices.find(c => c.id === choice.choiceId)
+        ) {
+          optionData.choices.push({ id: choice.choiceId, name: choice.name });
+        }
+      });
+    });
+  });
+
+  return optionsMap;
+}
+
+// Helper function to parse option filters from URL parameters
+function parseOptionFilters(
+  urlParams: Record<string, string | string[]>,
+  optionsMap: Map<
+    string,
+    { id: string; choices: { id: string; name: string }[] }
+  >,
+  filters: Filter
+) {
+  Object.entries(urlParams).forEach(([key, value]) => {
+    if (['sort', 'minPrice', 'maxPrice'].includes(key)) return;
+
+    const option = optionsMap.get(key);
+    if (option) {
+      const values = Array.isArray(value) ? value : [value];
+      const matchingChoices = option.choices.filter(choice =>
+        values.includes(choice.name)
+      );
+
+      if (matchingChoices.length > 0) {
+        filters.selectedOptions[option.id] = matchingChoices.map(c => c.id);
+      }
+    }
+  });
+}
+
+export async function loadCollectionServiceConfig(
+  categoryId?: string,
+  searchParams?: URLSearchParams,
+  preloadedCategories?: any[]
+): Promise<
+  ServiceFactoryConfig<typeof CollectionService> & {
+    initialCursor?: string;
+    initialHasMore?: boolean;
+    initialSort?: SortBy;
+    initialFilters?: Filter;
+  }
+> {
+  try {
+    // Use pre-loaded categories if provided, otherwise load them
+    let categories: any[];
+    if (preloadedCategories) {
+      categories = preloadedCategories;
+    } else {
+      const { loadCategoriesConfig } = await import('./category-service');
+      const categoriesConfig = await loadCategoriesConfig();
+      categories = categoriesConfig.categories;
+    }
+
+    // Build search options with category filter
+    const searchOptions = buildSearchOptions(undefined, categoryId, undefined);
+    const pageSize = 12;
+    searchOptions.paging = { limit: pageSize };
+
+    const productResults = await searchProducts(searchOptions);
+
+    // Parse URL parameters for initial state
+    const { initialSort, initialFilters } = parseURLParams(
+      searchParams,
+      productResults.products || []
+    );
+
+    return {
+      initialProducts: productResults.products || [],
+      pageSize,
+      initialCursor: productResults.pagingMetadata?.cursors?.next || undefined,
+      initialHasMore: Boolean(
+        productResults.pagingMetadata?.cursors?.next &&
+          productResults.products &&
+          productResults.products.length === pageSize
+      ),
+      initialSort,
+      initialFilters,
+      categories,
+    };
+  } catch (error) {
+    console.warn('Failed to load initial products:', error);
+    const { initialSort, initialFilters } = parseURLParams(searchParams);
+    return {
+      initialProducts: [],
+      pageSize: 12,
+      initialHasMore: false,
+      initialSort,
+      initialFilters,
+      categories: [],
+    };
+  }
+}
+
+// Add function to fetch missing variants for all products in one request
+const fetchMissingVariants = async (
+  products: productsV3.V3Product[]
+): Promise<productsV3.V3Product[]> => {
+  // Find products that need variants (both single and multi-variant products)
+  const productsNeedingVariants = products.filter(
+    product =>
+      !product.variantsInfo?.variants &&
+      product.variantSummary?.variantCount &&
+      product.variantSummary.variantCount > 0
+  );
+
+  if (productsNeedingVariants.length === 0) {
+    return products;
+  }
+
+  try {
+    const productIds = productsNeedingVariants
+      .map(p => p._id)
+      .filter(Boolean) as string[];
+
+    if (productIds.length === 0) {
+      return products;
+    }
+
+    const items = [];
+
+    const res = await readOnlyVariantsV3
+      .queryVariants({})
+      .in('productData.productId', productIds)
+      .limit(100)
+      .find();
+
+    items.push(...res.items);
+
+    let nextRes = res;
+    while (nextRes.hasNext()) {
+      nextRes = await nextRes.next();
+      items.push(...nextRes.items);
+    }
+
+    const variantsByProductId = new Map<string, productsV3.Variant[]>();
+
+    items.forEach(item => {
+      const productId = item.productData?.productId;
+      if (productId) {
+        if (!variantsByProductId.has(productId)) {
+          variantsByProductId.set(productId, []);
+        }
+        variantsByProductId.get(productId)!.push({
+          ...item,
+          choices: item.optionChoices as productsV3.Variant['choices'],
+        });
+      }
+    });
+
+    // Update products with their variants
+    return products.map(product => {
+      const variants = variantsByProductId.get(product._id || '');
+      if (variants && variants.length > 0) {
+        return {
+          ...product,
+          variantsInfo: {
+            ...product.variantsInfo,
+            variants,
+          },
+        };
+      }
+      return product;
+    });
+  } catch (error) {
+    console.error('Failed to fetch missing variants:', error);
+    return products;
+  }
+};

--- a/src/headless/store/services/filter-service.ts
+++ b/src/headless/store/services/filter-service.ts
@@ -1,0 +1,193 @@
+import { defineService, implementService } from '@wix/services-definitions';
+import { SignalsServiceDefinition } from '@wix/services-definitions/core-services/signals';
+import type {
+  Signal,
+  ReadOnlySignal,
+} from '@wix/services-definitions/core-services/signals';
+import { URLParamsUtils } from '../utils/url-params';
+import {
+  CatalogServiceDefinition,
+  type ProductOption,
+} from './catalog-service';
+
+export interface PriceRange {
+  min: number;
+  max: number;
+}
+
+export interface AvailableOptions {
+  productOptions: ProductOption[];
+  priceRange: PriceRange;
+}
+
+export interface Filter {
+  priceRange: { min: number; max: number };
+  selectedOptions: { [optionId: string]: string[] };
+}
+
+export interface FilterServiceAPI {
+  currentFilters: Signal<Filter>;
+  applyFilters: (filters: Filter) => Promise<void>;
+  clearFilters: () => Promise<void>;
+  availableOptions: ReadOnlySignal<{
+    productOptions: ProductOption[];
+    priceRange: { min: number; max: number };
+  }>;
+  isFullyLoaded: ReadOnlySignal<boolean>;
+}
+
+export const FilterServiceDefinition = defineService<FilterServiceAPI>(
+  'filtered-collection'
+);
+
+export const defaultFilter: Filter = {
+  priceRange: { min: 0, max: 0 },
+  selectedOptions: {},
+};
+
+export const FilterService = implementService.withConfig<{
+  initialFilters?: Filter;
+}>()(FilterServiceDefinition, ({ getService, config }) => {
+  const signalsService = getService(SignalsServiceDefinition);
+  const catalogService = getService(CatalogServiceDefinition);
+
+  const currentFilters: Signal<Filter> = signalsService.signal(
+    (config?.initialFilters || defaultFilter) as any
+  );
+
+  // Use computed signal for availableOptions to automatically track dependencies
+  const availableOptions = signalsService.computed(() => {
+    const catalogPriceRange = catalogService.catalogPriceRange.get();
+    const catalogOptions = catalogService.catalogOptions.get();
+
+    const priceRange =
+      catalogPriceRange &&
+      catalogPriceRange.minPrice < catalogPriceRange.maxPrice
+        ? { min: catalogPriceRange.minPrice, max: catalogPriceRange.maxPrice }
+        : { min: 0, max: 0 };
+
+    const productOptions =
+      catalogOptions && catalogOptions.length > 0 ? catalogOptions : [];
+
+    return {
+      productOptions,
+      priceRange,
+    };
+  });
+
+  // Use computed signal for isFullyLoaded to automatically track dependencies
+  const isFullyLoaded = signalsService.computed(() => {
+    const catalogPriceRange = catalogService.catalogPriceRange.get();
+    const catalogOptions = catalogService.catalogOptions.get();
+
+    // Price range data is considered loaded whether it's null (no prices) or has valid data
+    const hasPriceRangeData = catalogPriceRange !== undefined; // includes null case
+    const hasOptionsData = !!(catalogOptions && catalogOptions.length >= 0); // Even 0 options is valid
+
+    return hasPriceRangeData && hasOptionsData;
+  });
+
+  // Effect to update currentFilters when catalog data loads (only if filters are at defaults)
+  signalsService.effect(() => {
+    const catalogPriceRange = catalogService.catalogPriceRange.get();
+    if (
+      catalogPriceRange &&
+      catalogPriceRange.minPrice < catalogPriceRange.maxPrice
+    ) {
+      const priceRange = {
+        min: catalogPriceRange.minPrice,
+        max: catalogPriceRange.maxPrice,
+      };
+
+      // Update current filters to use catalog price range
+      const currentFiltersValue = currentFilters.get();
+      // Only update if current filter range is at defaults (either 0-0 or 0-1000)
+      const isDefaultRange =
+        (currentFiltersValue.priceRange.min === 0 &&
+          currentFiltersValue.priceRange.max === 0) ||
+        (currentFiltersValue.priceRange.min === 0 &&
+          currentFiltersValue.priceRange.max === 1000);
+
+      if (isDefaultRange) {
+        currentFilters.set({
+          ...currentFiltersValue,
+          priceRange,
+        });
+      }
+    }
+  });
+
+  // Apply filters by delegating to the collection service
+  const applyFilters = async (filters: Filter) => {
+    currentFilters.set(filters);
+
+    // Update URL with filter parameters
+    const urlParams: Record<string, string | string[]> = {};
+    const availableOpts = availableOptions.get();
+
+    // Add price filters if different from defaults
+    if (availableOpts?.priceRange) {
+      if (filters.priceRange.min > availableOpts.priceRange.min) {
+        urlParams.minPrice = filters.priceRange.min.toString();
+      }
+      if (filters.priceRange.max < availableOpts.priceRange.max) {
+        urlParams.maxPrice = filters.priceRange.max.toString();
+      }
+    }
+
+    // Add option filters using option names as keys
+    if (availableOpts?.productOptions) {
+      Object.entries(filters.selectedOptions).forEach(
+        ([optionId, choiceIds]) => {
+          const option = availableOpts.productOptions.find(
+            opt => opt.id === optionId
+          );
+          if (option && choiceIds.length > 0) {
+            const selectedChoices = option.choices.filter(choice =>
+              choiceIds.includes(choice.id)
+            );
+            if (selectedChoices.length > 0) {
+              // Use 'availability' as URL param for inventory filter
+              const paramName =
+                optionId === 'inventory-filter' ? 'availability' : option.name;
+              urlParams[paramName] = selectedChoices.map(choice => choice.name);
+            }
+          }
+        }
+      );
+    }
+
+    // Preserve existing sort parameter
+    const currentParams = URLParamsUtils.getURLParams();
+    if (currentParams.sort) {
+      urlParams.sort = currentParams.sort;
+    }
+
+    URLParamsUtils.updateURL(urlParams);
+  };
+
+  // Clear all filters by applying default filter state
+  const clearFilters = async () => {
+    const availablePriceRange = availableOptions.get()?.priceRange;
+    currentFilters.set({
+      ...defaultFilter,
+      priceRange: availablePriceRange || { min: 0, max: 0 },
+    });
+
+    // Clear filter parameters from URL, keeping only sort parameter
+    const currentParams = URLParamsUtils.getURLParams();
+    const urlParams: Record<string, string | string[]> = {};
+    if (currentParams.sort) {
+      urlParams.sort = currentParams.sort;
+    }
+    URLParamsUtils.updateURL(urlParams);
+  };
+
+  return {
+    currentFilters,
+    applyFilters,
+    clearFilters,
+    availableOptions,
+    isFullyLoaded,
+  };
+});

--- a/src/providers/WixServicesProvider.tsx
+++ b/src/providers/WixServicesProvider.tsx
@@ -30,13 +30,9 @@ import {
   CollectionServiceDefinition,
 } from '@wix/headless-stores/services';
 import {
-  CatalogPriceRangeService,
-  CatalogPriceRangeServiceDefinition,
-} from '@wix/headless-stores/services';
-import {
-  CatalogOptionsService,
-  CatalogOptionsServiceDefinition,
-} from '@wix/headless-stores/services';
+  CatalogService,
+  CatalogServiceDefinition,
+} from '../headless/store/services/catalog-service';
 import { StoreLayout } from '../layouts/StoreLayout';
 import {
   MediaGalleryService,
@@ -71,9 +67,8 @@ export default function WixServicesProvider({
     .addService(FilterServiceDefinition, FilterService)
     .addService(CategoryServiceDefinition, CategoryService)
     .addService(SortServiceDefinition, SortService)
-    .addService(CatalogPriceRangeServiceDefinition, CatalogPriceRangeService)
-    .addService(ProductModifiersServiceDefinition, ProductModifiersService)
-    .addService(CatalogOptionsServiceDefinition, CatalogOptionsService);
+    .addService(CatalogServiceDefinition, CatalogService)
+    .addService(ProductModifiersServiceDefinition, ProductModifiersService);
 
   return (
     <>

--- a/src/react-pages/store/example-1/index.tsx
+++ b/src/react-pages/store/example-1/index.tsx
@@ -2,13 +2,9 @@ import { createServicesMap } from '@wix/services-manager';
 import { useState } from 'react';
 import { PageDocsRegistration } from '../../../components/DocsMode';
 import {
-  CatalogOptionsService,
-  CatalogOptionsServiceDefinition,
-} from '@wix/headless-stores/services';
-import {
-  CatalogPriceRangeService,
-  CatalogPriceRangeServiceDefinition,
-} from '@wix/headless-stores/services';
+  CatalogService,
+  CatalogServiceDefinition,
+} from '../../../headless/store/services/catalog-service';
 import {
   CategoryService,
   CategoryServiceDefinition,
@@ -97,12 +93,7 @@ export default function StoreCollectionPage({
       .addService(SortServiceDefinition, SortService, {
         initialSort: filteredCollectionServiceConfig.initialSort,
       })
-      .addService(
-        CatalogPriceRangeServiceDefinition,
-        CatalogPriceRangeService,
-        {}
-      )
-      .addService(CatalogOptionsServiceDefinition, CatalogOptionsService, {})
+      .addService(CatalogServiceDefinition, CatalogService, {})
   );
 
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);

--- a/src/react-pages/store/example-2/index.tsx
+++ b/src/react-pages/store/example-2/index.tsx
@@ -28,13 +28,9 @@ import {
   SortServiceDefinition,
 } from '@wix/headless-stores/services';
 import {
-  CatalogPriceRangeService,
-  CatalogPriceRangeServiceDefinition,
-} from '@wix/headless-stores/services';
-import {
-  CatalogOptionsService,
-  CatalogOptionsServiceDefinition,
-} from '@wix/headless-stores/services';
+  CatalogService,
+  CatalogServiceDefinition,
+} from '../../../headless/store/services/catalog-service';
 
 interface StoreExample2PageProps {
   filteredCollectionServiceConfig: any;
@@ -597,12 +593,7 @@ export default function StoreExample2Page({
     .addService(SortServiceDefinition, SortService, {
       initialSort: filteredCollectionServiceConfig.initialSort,
     })
-    .addService(
-      CatalogPriceRangeServiceDefinition,
-      CatalogPriceRangeService,
-      {}
-    )
-    .addService(CatalogOptionsServiceDefinition, CatalogOptionsService, {});
+    .addService(CatalogServiceDefinition, CatalogService, {});
 
   return (
     <KitchensinkLayout>


### PR DESCRIPTION
## 1. Fixed the architectural problem where `FilterService` was making API calls when it should only manage filter state.

### Changes Made:

1. **Removed API methods from FilterService interface:**
   - Removed `loadCatalogPriceRange()` and `loadCatalogOptions()` from `FilterServiceAPI`

2. **Removed implementation from FilterService:**
   - Deleted the delegation methods that were calling catalog services
   - Removed them from the service's return object

3. **Updated CollectionService to handle all data loading:**
   - Added direct imports for `CatalogPriceRangeServiceDefinition` and `CatalogOptionsServiceDefinition`
   - Updated `initializeCatalogData()` to call catalog services directly instead of through FilterService
   - Made CollectionService fully responsible for data fetching

### Result:

✅ **Clean Separation of Concerns:**
- **FilterService**: Pure state management (filters, URL params)
- **CollectionService**: All data fetching (products, catalog data)

✅ **No More Circular Dependencies:**
- FilterService no longer calls external APIs
- CollectionService handles all data loading responsibilities

✅ **Better Architecture:**
- Single source of truth for data loading
- Cleaner service boundaries
- Easier to test and maintain

## 2. Successfully Merged Catalog Services

Merged the two separate catalog services into a single combined service that loads all catalog data with one API call instead of multiple calls.

### What Was Done:

1. **Created Combined Service** (`catalog-service.ts`):
   - Single aggregation request for both price range AND options data
   - Combines price range aggregations (MIN/MAX) with options aggregations (VALUE types)
   - Parallel API calls to both `productsV3.searchProducts()` and `customizationsV3.queryCustomizations()`
   - Provides both `catalogOptions` and `catalogPriceRange` signals

2. **Updated All Consuming Code**:
   - `FilterService`: Updated to use `CatalogServiceDefinition` instead of two separate services
   - `CollectionService`: Now calls `catalogService.loadCatalogData()` instead of two separate methods
   - Store example pages: Updated imports and service configurations
   - `WixServicesProvider`: Updated to register the new combined service

3. **Cleaned Up Old Services**:
   - Deleted `catalog-options-service.ts` and `catalog-price-range-service.ts`
   - Fixed all import references throughout the codebase

### Performance Improvement:

**Before**: 2 separate API calls
- `loadCatalogPriceRange()` → `productsV3.searchProducts()` (price aggregation)
- `loadCatalogOptions()` → `productsV3.searchProducts()` (options aggregation) + `customizationsV3.queryCustomizations()`

**After**: 1 combined API call
- `loadCatalogData()` → **Single** `productsV3.searchProducts()` (both price AND options aggregations) + `customizationsV3.queryCustomizations()`

### Benefits:

✅ **50% fewer API calls** - from 2 to 1 aggregation request  
✅ **Faster loading** - reduced network overhead  
✅ **Better architecture** - single responsibility for catalog data  
✅ **Maintained functionality** - all existing features work identically  
✅ **Cleaner code** - simpler service management



Before:
<img width="434" height="502" alt="image" src="https://github.com/user-attachments/assets/34d92fe7-f13e-4a75-81d5-b1c5143cd5f9" />

After:
<img width="341" height="380" alt="image" src="https://github.com/user-attachments/assets/5c25c98c-b4e4-450c-80d2-890b553bff80" />
