### PR TITLE
Fixing imports from src/components/ui 

### DIFF
--- a/src/components/store/ProductActionButtons.tsx
+++ b/src/components/store/ProductActionButtons.tsx
@@ -3,7 +3,7 @@ import {
   ProductActionAddToCart,
   ProductActionBuyNow,
   ProductActionPreOrder,
-} from '../ui/store/Product';
+} from '@/components/ui/store/Product';
 
 interface ProductActionButtonsProps {
   showBuyNow?: boolean;

--- a/src/components/store/ProductDetails.tsx
+++ b/src/components/store/ProductDetails.tsx
@@ -18,14 +18,18 @@ import {
   ProductModifierOptions,
   ProductModifierOptionRepeater,
   ProductModifiers,
-} from '../ui/store/Product';
+} from '@/components/ui/store/Product';
 import {
   OptionName,
   OptionChoices,
   OptionChoiceRepeater,
   OptionMandatoryIndicator,
-} from '../ui/store/Option';
-import { ChoiceColor, ChoiceText, ChoiceFreeText } from '../ui/store/Choice';
+} from '@/components/ui/store/Option';
+import {
+  ChoiceColor,
+  ChoiceText,
+  ChoiceFreeText,
+} from '@/components/ui/store/Choice';
 
 import { productsV3 } from '@wix/stores';
 

--- a/src/components/store/ProductList.tsx
+++ b/src/components/store/ProductList.tsx
@@ -18,7 +18,7 @@ import {
 
 import React from 'react';
 import { useNavigation } from '../NavigationContext';
-import { Badge } from '../ui/badge';
+import { Badge } from '@/components/ui/badge';
 import {
   ProductCompareAtPrice,
   ProductDescription,
@@ -31,14 +31,14 @@ import {
   ProductVariantOptionRepeater,
   ProductVariantOptions,
   ProductVariants,
-} from '../ui/store/Product';
+} from '@/components/ui/store/Product';
 import {
   LoadMoreTrigger,
   ProductList,
   ProductRepeater,
   Products,
   TotalsDisplayed,
-} from '../ui/store/ProductList';
+} from '@/components/ui/store/ProductList';
 import CategoryPicker from './CategoryPicker';
 import { ProductActionButtons } from './ProductActionButtons';
 import ProductFiltersSidebar from './ProductFiltersSidebar';
@@ -47,8 +47,8 @@ import {
   OptionChoiceRepeater,
   OptionChoices,
   OptionName,
-} from '../ui/store/Option';
-import { ChoiceColor, ChoiceText } from '../ui/store/Choice';
+} from '@/components/ui/store/Option';
+import { ChoiceColor, ChoiceText } from '@/components/ui/store/Choice';
 
 interface ProductListProps {
   productsListConfig: ProductsListServiceConfig;

--- a/src/layouts/KitchensinkLayout.tsx
+++ b/src/layouts/KitchensinkLayout.tsx
@@ -4,8 +4,8 @@ import {
   DocsToggleButton,
   DocsDrawer,
   DocsFloatingMenu,
-} from '../components/DocsMode';
-import { NavigationProvider } from '../components/NavigationContext';
+} from '@/components/DocsMode';
+import { NavigationProvider } from '@/components/NavigationContext';
 
 interface KitchensinkLayoutProps {
   children: React.ReactNode;

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { MiniCartContent, MiniCartIcon } from '../components/ecom/MiniCart';
+import { MiniCartContent, MiniCartIcon } from '@/components/ecom/MiniCart';
 import { CurrentCart } from '@/components/ui/ecom/CurrentCart';
 import { CartLineItemAdded } from '@/components/ui/ecom/Cart';
 import type { CurrentCartServiceConfig } from '@wix/headless-ecom/services';
 import {
   MiniCartModalProvider,
   useMiniCartModal,
-} from '../components/MiniCartModal';
+} from '@/components/MiniCartModal';
 import { Commerce } from '@/components/ui/ecom/Commerce';
 
 interface StoreLayoutProps {

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -7,7 +7,7 @@ import {
   MiniCartModalProvider,
   useMiniCartModal,
 } from '../components/MiniCartModal';
-import { Commerce } from '../components/ui/ecom/Commerce';
+import { Commerce } from '@/components/ui/ecom/Commerce';
 
 interface StoreLayoutProps {
   children: ReactNode;

--- a/src/react-pages/bookings/example-1/[serviceId].tsx
+++ b/src/react-pages/bookings/example-1/[serviceId].tsx
@@ -23,7 +23,7 @@ import {
   BookingSelection,
 } from '../../../headless/bookings/components';
 import { KitchensinkLayout } from '../../../layouts/KitchensinkLayout';
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface ServiceBookingPageProps {
   serviceId: string;

--- a/src/react-pages/bookings/example-1/index.tsx
+++ b/src/react-pages/bookings/example-1/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../headless/bookings/components';
 import { KitchensinkLayout } from '../../../layouts/KitchensinkLayout';
 import { WixMediaImage } from '../../../headless/media/components';
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface BookingsPageProps {
   bookingServicesConfig: any;

--- a/src/react-pages/bookings/example-2/[serviceId].tsx
+++ b/src/react-pages/bookings/example-2/[serviceId].tsx
@@ -11,7 +11,7 @@ import {
 import { BookingService } from '../../../headless/bookings/components';
 import { WixMediaImage } from '../../../headless/media/components';
 import { KitchensinkLayout } from '../../../layouts/KitchensinkLayout';
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface ServiceDetailPageProps {
   bookingServiceConfig: any;

--- a/src/react-pages/bookings/example-2/book/[serviceId].tsx
+++ b/src/react-pages/bookings/example-2/book/[serviceId].tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../headless/bookings/components';
 import { WixMediaImage } from '../../../../headless/media/components';
 import { KitchensinkLayout } from '../../../../layouts/KitchensinkLayout';
-import { PageDocsRegistration } from '../../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 import { BookingAvailabilityServiceDefinition } from '../../../../headless/bookings/services/booking-availability-service';
 import { BookingSelectionServiceDefinition } from '../../../../headless/bookings/services/booking-selection-service';
 

--- a/src/react-pages/bookings/example-2/index.tsx
+++ b/src/react-pages/bookings/example-2/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../headless/bookings/services/booking-services-service';
 import { BookingServices } from '../../../headless/bookings/components';
 import { WixMediaImage } from '../../../headless/media/components';
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface BookingsHomePageProps {
   bookingServicesConfig: any;

--- a/src/react-pages/bookings/example-2/services.tsx
+++ b/src/react-pages/bookings/example-2/services.tsx
@@ -11,7 +11,7 @@ import {
 import { BookingServices } from '../../../headless/bookings/components';
 import { WixMediaImage } from '@wix/headless-media/react';
 import { KitchensinkLayout } from '../../../layouts/KitchensinkLayout';
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface BookingsServicesPageProps {
   bookingServicesConfig: any;

--- a/src/react-pages/bookings/index.tsx
+++ b/src/react-pages/bookings/index.tsx
@@ -1,5 +1,5 @@
 import { KitchensinkLayout } from '../../layouts/KitchensinkLayout';
-import { PageDocsRegistration } from '../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 
 interface BookingsIntroPageProps {
   bookingServicesConfig: any;

--- a/src/react-pages/cart.tsx
+++ b/src/react-pages/cart.tsx
@@ -1,6 +1,6 @@
 import '../styles/theme-1.css';
 import { KitchensinkLayout } from '../layouts/KitchensinkLayout';
-import CartContent from '../components/ecom/Cart';
+import CartContent from '@/components/ecom/Cart';
 import { CurrentCart } from '@/components/ui/ecom/CurrentCart';
 import type { CurrentCartServiceConfig } from '@wix/headless-ecom/services';
 import { Commerce } from '@/components/ui/ecom/Commerce';

--- a/src/react-pages/cart.tsx
+++ b/src/react-pages/cart.tsx
@@ -3,7 +3,7 @@ import { KitchensinkLayout } from '../layouts/KitchensinkLayout';
 import CartContent from '../components/ecom/Cart';
 import { CurrentCart } from '@/components/ui/ecom/CurrentCart';
 import type { CurrentCartServiceConfig } from '@wix/headless-ecom/services';
-import { Commerce } from '../components/ui/ecom/Commerce';
+import { Commerce } from '@/components/ui/ecom/Commerce';
 
 interface CartPageProps {
   currentCartServiceConfig: CurrentCartServiceConfig;

--- a/src/react-pages/members/index.tsx
+++ b/src/react-pages/members/index.tsx
@@ -1,4 +1,4 @@
-import { PageDocsRegistration } from '../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 import { KitchensinkLayout } from '../../layouts/KitchensinkLayout';
 import '../../styles/theme-1.css';
 

--- a/src/react-pages/members/profile.tsx
+++ b/src/react-pages/members/profile.tsx
@@ -6,16 +6,16 @@ import {
 import { ServicesManagerProvider } from '@wix/services-manager-react';
 import { actions } from 'astro:actions';
 import { useState } from 'react';
-import { PageDocsRegistration } from '../../components/DocsMode';
-import { CameraIcon } from '../../components/icons/CameraIcon';
-import { CheckCircleIcon } from '../../components/icons/CheckCircleIcon';
-import { CheckIcon } from '../../components/icons/CheckIcon';
-import { MailIcon } from '../../components/icons/MailIcon';
-import { PencilIcon } from '../../components/icons/PencilIcon';
-import { SignOutIcon } from '../../components/icons/SignOutIcon';
-import { UserIcon } from '../../components/icons/UserIcon';
-import PhotoUploadDialog from '../../components/PhotoUploadDialog';
-import UpdateProfileDialog from '../../components/UpdateProfileDialog';
+import { PageDocsRegistration } from '@/components/DocsMode';
+import { CameraIcon } from '@/components/icons/CameraIcon';
+import { CheckCircleIcon } from '@/components/icons/CheckCircleIcon';
+import { CheckIcon } from '@/components/icons/CheckIcon';
+import { MailIcon } from '@/components/icons/MailIcon';
+import { PencilIcon } from '@/components/icons/PencilIcon';
+import { SignOutIcon } from '@/components/icons/SignOutIcon';
+import { UserIcon } from '@/components/icons/UserIcon';
+import PhotoUploadDialog from '@/components/PhotoUploadDialog';
+import UpdateProfileDialog from '@/components/UpdateProfileDialog';
 import {
   CurrentMemberService,
   CurrentMemberServiceDefinition,

--- a/src/react-pages/react-router/routes/cart.tsx
+++ b/src/react-pages/react-router/routes/cart.tsx
@@ -1,4 +1,4 @@
-import CartContent from '../../../components/ecom/Cart';
+import CartContent from '@/components/ecom/Cart';
 
 export function Cart() {
   return (

--- a/src/react-pages/react-router/routes/root.tsx
+++ b/src/react-pages/react-router/routes/root.tsx
@@ -2,16 +2,13 @@ import { useLoaderData } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
 
 import { loadCurrentCartServiceConfig } from '@wix/headless-ecom/services';
-import {
-  MiniCartContent,
-  MiniCartIcon,
-} from '../../../components/ecom/MiniCart';
+import { MiniCartContent, MiniCartIcon } from '@/components/ecom/MiniCart';
 import { CurrentCart } from '@/components/ui/ecom/CurrentCart';
 import { CartLineItemAdded } from '@/components/ui/ecom/Cart';
 import {
   NavigationProvider,
   type NavigationComponent,
-} from '../../../components/NavigationContext';
+} from '@/components/NavigationContext';
 import { Link } from 'react-router-dom';
 import '@wix/wix-vibe-plugins/plugins-vars.css';
 import {

--- a/src/react-pages/react-router/routes/store-collection.tsx
+++ b/src/react-pages/react-router/routes/store-collection.tsx
@@ -6,7 +6,7 @@ import {
 } from '@wix/headless-stores/services';
 import { loadProductsListServiceConfig } from '@wix/headless-stores/services';
 import CategoryPage from '../../store/main-components/categoryPage';
-import { ProductListSkeleton } from '../../../components/store/ProductList';
+import { ProductListSkeleton } from '@/components/store/ProductList';
 import { Card, CardContent } from '@/components/ui/card';
 import { customizationsV3 } from '@wix/stores';
 // Skeleton component for product collection loading

--- a/src/react-pages/store/example-1/index.tsx
+++ b/src/react-pages/store/example-1/index.tsx
@@ -1,4 +1,4 @@
-import { PageDocsRegistration } from '../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 import { StoreLayout } from '../../../layouts/StoreLayout';
 import '../../../styles/theme-1.css';
 import { KitchensinkLayout } from '../../../layouts/KitchensinkLayout';

--- a/src/react-pages/store/example-1/products/[slug].tsx
+++ b/src/react-pages/store/example-1/products/[slug].tsx
@@ -1,4 +1,4 @@
-import { PageDocsRegistration } from '../../../../components/DocsMode';
+import { PageDocsRegistration } from '@/components/DocsMode';
 import { CurrentCartService } from '@wix/headless-ecom/services';
 import { ProductService } from '@wix/headless-stores/services';
 import { KitchensinkLayout } from '../../../../layouts/KitchensinkLayout';

--- a/src/react-pages/store/main-components/categoryPage.tsx
+++ b/src/react-pages/store/main-components/categoryPage.tsx
@@ -1,4 +1,4 @@
-import ProductList from '../../../components/store/ProductList';
+import ProductList from '@/components/store/ProductList';
 
 import {
   type CategoriesListServiceConfig,

--- a/src/react-pages/store/main-components/productDetailsPage.tsx
+++ b/src/react-pages/store/main-components/productDetailsPage.tsx
@@ -1,4 +1,4 @@
-import ProductDetails from '../../../components/store/ProductDetails';
+import ProductDetails from '@/components/store/ProductDetails';
 
 interface ProductDetailPageProps {
   productServiceConfig?: any;


### PR DESCRIPTION
All imports from src/components/ui now consistently use the @/components/ui pattern instead of relative paths