### PR TITLE
ecom: remove mini cart icon size styling

### DIFF
--- a/src/components/ecom/MiniCart.tsx
+++ b/src/components/ecom/MiniCart.tsx
@@ -133,9 +133,8 @@ const CouponFormMini = ({
 };
 
 const DefaultMiniCartIcon = () => (
-  <div className="p-2 text-content-primary ">
+  <div className="text-content-primary ">
     <svg
-      className="w-6 h-6"
       fill="none"
       stroke="currentColor"
       viewBox="0 0 24 24"
@@ -242,10 +241,9 @@ export function MiniCartContent() {
             onClick={close}
             variant="ghost"
             size="icon"
-            className="p-2 text-content-primary hover:text-brand-light transition-colors"
+            className="text-content-primary hover:text-brand-light transition-colors"
           >
             <svg
-              className="w-6 h-6"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/src/components/ecom/MiniCart.tsx
+++ b/src/components/ecom/MiniCart.tsx
@@ -134,11 +134,7 @@ const CouponFormMini = ({
 
 const DefaultMiniCartIcon = () => (
   <div className="text-content-primary ">
-    <svg
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-    >
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -243,11 +239,7 @@ export function MiniCartContent() {
             size="icon"
             className="text-content-primary hover:text-brand-light transition-colors"
           >
-            <svg
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"


### PR DESCRIPTION
remove size styling from mini cart as it causes misalignment when the LLM composes the icon inside a header