### PR TITLE
minicart-icon: remove default classname #pr

### DIFF
--- a/src/components/ecom/MiniCart.tsx
+++ b/src/components/ecom/MiniCart.tsx
@@ -147,7 +147,7 @@ const DefaultMiniCartIcon = () => (
 
 export function MiniCartIcon({
   Icon = DefaultMiniCartIcon,
-  className = 'fixed top-6 right-6 z-50',
+  className,
 }: { Icon?: React.ComponentType; className?: string } = {}) {
   const { open } = useMiniCartContext();
   return (

--- a/src/layouts/StoreLayout.tsx
+++ b/src/layouts/StoreLayout.tsx
@@ -89,7 +89,7 @@ function StoreLayoutContent({
         </div>
       )}
 
-      <MiniCartIcon />
+      <MiniCartIcon className="fixed top-6 right-6 z-50" />
 
       {/* Main Content */}
       {children}


### PR DESCRIPTION
extract fixed class names for the minicart icon to the kitchensink layout